### PR TITLE
⬆️ Bump Ubuntu from 20.04 to 22.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
     - cron:  '0 0 * * *'
 jobs:
   script:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Get Job URL
       uses: Tiryoh/gha-jobid-action@v0


### PR DESCRIPTION
Subject: Bump Ubuntu from 20.04 to 22.04

### Feature or Bugfix
<!-- please choose -->
- Maintenance

### Purpose
- Bump Ubuntu from 20.04 to 22.04

### Detail
- None

### Relates
- None

