### PR TITLE
🔥 Cleanup apt_packages of .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,16 +9,6 @@ sphinx:
 build:
   os: "ubuntu-22.04"
   apt_packages:
-    - automake
-    - libtool
-    - make
-    - g++
-    - libqd-dev
-    - libqhull-dev
-    - libmumps-seq-dev
-    - liblapack-dev
-    - libopenblas-dev
-    - libpython3-dev
     - dcraw
     - imagemagick
     - fig2dev
@@ -26,7 +16,6 @@ build:
     - xzdec
     - fig2ps
     - gv
-    - python3-vtk7
   tools:
     python: "mambaforge-4.10"
   jobs:


### PR DESCRIPTION
Subject: 🔥 Cleaup apt_packages of .readthedocs.yaml

### Feature or Bugfix
<!-- please choose -->
- Maint

### Purpose
- 🔥 Cleanup apt_packages of .readthedocs.yaml

### Detail
- None

### Relates
- None

