### PR TITLE
ci: remove token from checkout action for public submodules

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
           submodules: true
-          token: ${{ secrets.PERSONAL_ACCESSTOKEN }}
       - name: Setup SSH
         uses: MrSquaare/ssh-setup-action@c818628b924a4bd863903a56c0e526db47bba6f4 # v3
         with:


### PR DESCRIPTION
The submodules in this repository are all public, so a Personal Access Token is not required for `actions/checkout`. Removing it resolves the Dependabot workflow error: `Input required and not supplied: token`.